### PR TITLE
install *.hpp header files as well

### DIFF
--- a/joint_trajectory_execution/CMakeLists.txt
+++ b/joint_trajectory_execution/CMakeLists.txt
@@ -92,7 +92,9 @@ install(TARGETS trajectory_action_server
 ## Mark cpp header files for installation
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-  FILES_MATCHING PATTERN "*.h"
+  FILES_MATCHING 
+    PATTERN "*.h"
+    PATTERN "*.hpp"
 )
 
 if (EXISTS ${CMAKE_CURRENT_BINARY_DIR}/docs/html)


### PR DESCRIPTION
When using your tools with plain cmake instead of catkin the JointVelocityTracker.hpp file was not installed.
This patch fixes this issue.
